### PR TITLE
Add publishConfig for public access in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
   ],
   "author": "",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
     "zod": "^3.23.8"


### PR DESCRIPTION
Include a publishConfig section in package.json to enable public access for the package.